### PR TITLE
*.spec: add directory itself to %files

### DIFF
--- a/iosevka-aile-fonts/iosevka-aile-fonts.spec
+++ b/iosevka-aile-fonts/iosevka-aile-fonts.spec
@@ -45,7 +45,7 @@ npm run build -- ttf::IosevkaAile
 %files -n iosevka-aile-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-aile-fonts/*
+%{_datadir}/fonts/iosevka-aile-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-curly-fonts/iosevka-curly-fonts.spec
+++ b/iosevka-curly-fonts/iosevka-curly-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedCurly
 %files -n iosevka-curly-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-curly-fonts/*
+%{_datadir}/fonts/iosevka-curly-fonts
 
 %files -n iosevka-term-curly-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-curly-fonts/*
+%{_datadir}/fonts/iosevka-term-curly-fonts
 
 %files -n iosevka-fixed-curly-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-curly-fonts/*
+%{_datadir}/fonts/iosevka-fixed-curly-fonts
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-curly-slab-fonts/iosevka-curly-slab-fonts.spec
+++ b/iosevka-curly-slab-fonts/iosevka-curly-slab-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedCurlySlab
 %files -n iosevka-curly-slab-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-curly-slab-fonts/*
+%{_datadir}/fonts/iosevka-curly-slab-fonts/
 
 %files -n iosevka-term-curly-slab-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-curly-slab-fonts/*
+%{_datadir}/fonts/iosevka-term-curly-slab-fonts/
 
 %files -n iosevka-fixed-curly-slab-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-curly-slab-fonts/*
+%{_datadir}/fonts/iosevka-fixed-curly-slab-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-etoile-fonts/iosevka-etoile-fonts.spec
+++ b/iosevka-etoile-fonts/iosevka-etoile-fonts.spec
@@ -44,7 +44,7 @@ npm run build -- ttf::IosevkaEtoile
 %files -n iosevka-etoile-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-etoile-fonts/*
+%{_datadir}/fonts/iosevka-etoile-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-fonts/iosevka-fonts.spec
+++ b/iosevka-fonts/iosevka-fonts.spec
@@ -57,17 +57,17 @@ npm run build -- ttf::IosevkaFixed
 %files -n iosevka-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fonts/*
+%{_datadir}/fonts/iosevka-fonts
 
 %files -n iosevka-term-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-fonts/*
+%{_datadir}/fonts/iosevka-term-fonts
 
 %files -n iosevka-fixed-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-fonts/*
+%{_datadir}/fonts/iosevka-fixed-fonts
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-slab-fonts/iosevka-slab-fonts.spec
+++ b/iosevka-slab-fonts/iosevka-slab-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSlab
 %files -n iosevka-slab-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-slab-fonts/*
+%{_datadir}/fonts/iosevka-slab-fonts/
 
 %files -n iosevka-term-slab-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-slab-fonts/*
+%{_datadir}/fonts/iosevka-term-slab-fonts/
 
 %files -n iosevka-fixed-slab-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-slab-fonts/*
+%{_datadir}/fonts/iosevka-fixed-slab-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss01-fonts/iosevka-ss01-fonts.spec
+++ b/iosevka-ss01-fonts/iosevka-ss01-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS01
 %files -n iosevka-ss01-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss01-fonts/*
+%{_datadir}/fonts/iosevka-ss01-fonts/
 
 %files -n iosevka-term-ss01-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss01-fonts/*
+%{_datadir}/fonts/iosevka-term-ss01-fonts/
 
 %files -n iosevka-fixed-ss01-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss01-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss01-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss02-fonts/iosevka-ss02-fonts.spec
+++ b/iosevka-ss02-fonts/iosevka-ss02-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS02
 %files -n iosevka-ss02-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss02-fonts/*
+%{_datadir}/fonts/iosevka-ss02-fonts/
 
 %files -n iosevka-term-ss02-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss02-fonts/*
+%{_datadir}/fonts/iosevka-term-ss02-fonts/
 
 %files -n iosevka-fixed-ss02-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss02-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss02-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss03-fonts/iosevka-ss03-fonts.spec
+++ b/iosevka-ss03-fonts/iosevka-ss03-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS03
 %files -n iosevka-ss03-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss03-fonts/*
+%{_datadir}/fonts/iosevka-ss03-fonts/
 
 %files -n iosevka-term-ss03-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss03-fonts/*
+%{_datadir}/fonts/iosevka-term-ss03-fonts/
 
 %files -n iosevka-fixed-ss03-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss03-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss03-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss04-fonts/iosevka-ss04-fonts.spec
+++ b/iosevka-ss04-fonts/iosevka-ss04-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS04
 %files -n iosevka-ss04-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss04-fonts/*
+%{_datadir}/fonts/iosevka-ss04-fonts/
 
 %files -n iosevka-term-ss04-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss04-fonts/*
+%{_datadir}/fonts/iosevka-term-ss04-fonts/
 
 %files -n iosevka-fixed-ss04-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss04-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss04-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss05-fonts/iosevka-ss05-fonts.spec
+++ b/iosevka-ss05-fonts/iosevka-ss05-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS05
 %files -n iosevka-ss05-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss05-fonts/*
+%{_datadir}/fonts/iosevka-ss05-fonts/
 
 %files -n iosevka-term-ss05-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss05-fonts/*
+%{_datadir}/fonts/iosevka-term-ss05-fonts/
 
 %files -n iosevka-fixed-ss05-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss05-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss05-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss06-fonts/iosevka-ss06-fonts.spec
+++ b/iosevka-ss06-fonts/iosevka-ss06-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS06
 %files -n iosevka-ss06-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss06-fonts/*
+%{_datadir}/fonts/iosevka-ss06-fonts/
 
 %files -n iosevka-term-ss06-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss06-fonts/*
+%{_datadir}/fonts/iosevka-term-ss06-fonts/
 
 %files -n iosevka-fixed-ss06-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss06-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss06-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss07-fonts/iosevka-ss07-fonts.spec
+++ b/iosevka-ss07-fonts/iosevka-ss07-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS07
 %files -n iosevka-ss07-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss07-fonts/*
+%{_datadir}/fonts/iosevka-ss07-fonts/
 
 %files -n iosevka-term-ss07-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss07-fonts/*
+%{_datadir}/fonts/iosevka-term-ss07-fonts/
 
 %files -n iosevka-fixed-ss07-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss07-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss07-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss08-fonts/iosevka-ss08-fonts.spec
+++ b/iosevka-ss08-fonts/iosevka-ss08-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS08
 %files -n iosevka-ss08-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss08-fonts/*
+%{_datadir}/fonts/iosevka-ss08-fonts/
 
 %files -n iosevka-term-ss08-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss08-fonts/*
+%{_datadir}/fonts/iosevka-term-ss08-fonts/
 
 %files -n iosevka-fixed-ss08-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss08-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss08-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss09-fonts/iosevka-ss09-fonts.spec
+++ b/iosevka-ss09-fonts/iosevka-ss09-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS09
 %files -n iosevka-ss09-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss09-fonts/*
+%{_datadir}/fonts/iosevka-ss09-fonts/
 
 %files -n iosevka-term-ss09-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss09-fonts/*
+%{_datadir}/fonts/iosevka-term-ss09-fonts/
 
 %files -n iosevka-fixed-ss09-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss09-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss09-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss10-fonts/iosevka-ss10-fonts.spec
+++ b/iosevka-ss10-fonts/iosevka-ss10-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS10
 %files -n iosevka-ss10-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss10-fonts/*
+%{_datadir}/fonts/iosevka-ss10-fonts/
 
 %files -n iosevka-term-ss10-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss10-fonts/*
+%{_datadir}/fonts/iosevka-term-ss10-fonts/
 
 %files -n iosevka-fixed-ss10-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss10-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss10-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss11-fonts/iosevka-ss11-fonts.spec
+++ b/iosevka-ss11-fonts/iosevka-ss11-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS11
 %files -n iosevka-ss11-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss11-fonts/*
+%{_datadir}/fonts/iosevka-ss11-fonts/
 
 %files -n iosevka-term-ss11-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss11-fonts/*
+%{_datadir}/fonts/iosevka-term-ss11-fonts/
 
 %files -n iosevka-fixed-ss11-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss11-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss11-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss12-fonts/iosevka-ss12-fonts.spec
+++ b/iosevka-ss12-fonts/iosevka-ss12-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS12
 %files -n iosevka-ss12-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss12-fonts/*
+%{_datadir}/fonts/iosevka-ss12-fonts/
 
 %files -n iosevka-term-ss12-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss12-fonts/*
+%{_datadir}/fonts/iosevka-term-ss12-fonts/
 
 %files -n iosevka-fixed-ss12-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss12-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss12-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss13-fonts/iosevka-ss13-fonts.spec
+++ b/iosevka-ss13-fonts/iosevka-ss13-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS13
 %files -n iosevka-ss13-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss13-fonts/*
+%{_datadir}/fonts/iosevka-ss13-fonts/
 
 %files -n iosevka-term-ss13-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss13-fonts/*
+%{_datadir}/fonts/iosevka-term-ss13-fonts/
 
 %files -n iosevka-fixed-ss13-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss13-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss13-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss14-fonts/iosevka-ss14-fonts.spec
+++ b/iosevka-ss14-fonts/iosevka-ss14-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS14
 %files -n iosevka-ss14-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss14-fonts/*
+%{_datadir}/fonts/iosevka-ss14-fonts/
 
 %files -n iosevka-term-ss14-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss14-fonts/*
+%{_datadir}/fonts/iosevka-term-ss14-fonts/
 
 %files -n iosevka-fixed-ss14-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss14-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss14-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss15-fonts/iosevka-ss15-fonts.spec
+++ b/iosevka-ss15-fonts/iosevka-ss15-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS15
 %files -n iosevka-ss15-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss15-fonts/*
+%{_datadir}/fonts/iosevka-ss15-fonts/
 
 %files -n iosevka-term-ss15-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss15-fonts/*
+%{_datadir}/fonts/iosevka-term-ss15-fonts/
 
 %files -n iosevka-fixed-ss15-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss15-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss15-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss16-fonts/iosevka-ss16-fonts.spec
+++ b/iosevka-ss16-fonts/iosevka-ss16-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS16
 %files -n iosevka-ss16-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss16-fonts/*
+%{_datadir}/fonts/iosevka-ss16-fonts/
 
 %files -n iosevka-term-ss16-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss16-fonts/*
+%{_datadir}/fonts/iosevka-term-ss16-fonts/
 
 %files -n iosevka-fixed-ss16-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss16-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss16-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss17-fonts/iosevka-ss17-fonts.spec
+++ b/iosevka-ss17-fonts/iosevka-ss17-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS17
 %files -n iosevka-ss17-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss17-fonts/*
+%{_datadir}/fonts/iosevka-ss17-fonts/
 
 %files -n iosevka-term-ss17-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss17-fonts/*
+%{_datadir}/fonts/iosevka-term-ss17-fonts/
 
 %files -n iosevka-fixed-ss17-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss17-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss17-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0

--- a/iosevka-ss18-fonts/iosevka-ss18-fonts.spec
+++ b/iosevka-ss18-fonts/iosevka-ss18-fonts.spec
@@ -58,17 +58,17 @@ npm run build -- ttf::IosevkaFixedSS18
 %files -n iosevka-ss18-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-ss18-fonts/*
+%{_datadir}/fonts/iosevka-ss18-fonts/
 
 %files -n iosevka-term-ss18-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-term-ss18-fonts/*
+%{_datadir}/fonts/iosevka-term-ss18-fonts/
 
 %files -n iosevka-fixed-ss18-fonts
 %license LICENSE.md
 %doc README.md
-%{_datadir}/fonts/iosevka-fixed-ss18-fonts/*
+%{_datadir}/fonts/iosevka-fixed-ss18-fonts/
 
 %changelog
 * Sat Aug 17 11:54:25 EDT 2024 Peter Wu - v31.3.0


### PR DESCRIPTION
This fixes two issues wrt packaging:

1. rpm -qf /usr/share/fonts/iosevka-*-fonts shows "file ... is not owned by any package".

2. When any of these rpms are installed and then removed, an empty directory (like /usr/share/fonts/iosevka-*-fonts/) remains on the host.

Brought to you by
```bash    
for f in $(git ls-files \*.spec); do sed -i -e 's/\*$//' $f; done
```

PTAL @peterwu 